### PR TITLE
Enable balance retrieval for treasury contracts

### DIFF
--- a/src/formulas/formulas/contract/xion/account.ts
+++ b/src/formulas/formulas/contract/xion/account.ts
@@ -69,7 +69,7 @@ export const treasuries: ContractFormula<
     return Promise.all(
       treasuryContracts.map(async ({ contractAddress, block, codeId }) => ({
         contractAddress,
-        // balances: await getBalances(contractAddress),
+        balances: await getBalances(contractAddress),
         block: {
           height: block.height.toString(),
           timeUnixMs: block.timeUnixMs.toString(),


### PR DESCRIPTION
Reinstates the call to `getBalances` to fetch balances for treasury contracts. This ensures the necessary balance data is returned alongside other contract details.