### PR TITLE
feat: notify ops repo on version tag releases

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -79,3 +79,21 @@ jobs:
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
+
+  notify-ops:
+    needs: [build-and-push]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify ops of new release
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.OPS_REPO_PAT }}
+          repository: NoahSaso/intentional-design-ops
+          event-type: argus-fork-release
+          client-payload: >
+            {
+              "repo": "${{ github.repository }}",
+              "tag": "${{ github.ref_name }}",
+              "sha": "${{ github.sha }}"
+            }


### PR DESCRIPTION
Adds a `notify-ops` job to the Docker build workflow that sends a `repository_dispatch` event to the ops repo when a version tag (`v*`) is pushed.

This enables automated version tracking — when a new argus release is tagged and its Docker image is built, the ops repo is notified so it can update the chain version config automatically.

### What it does
- Fires only on `refs/tags/v*` pushes (not branch pushes or PRs)
- Sends `{repo, tag, sha}` payload to the ops repo's `auto-upgrade.yml` workflow
- Requires `OPS_REPO_PAT` secret (fine-grained PAT with `contents: write` on the ops repo)

### Setup
Add `OPS_REPO_PAT` as a repository secret — a fine-grained GitHub PAT scoped to `contents: write` on `NoahSaso/intentional-design-ops`.