### PR TITLE
fix: copy package.json to dist/ for version.ts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ COPY . .
 # Build the application
 RUN npm run build:only
 
+# Copy package.json to dist/ for version.ts to read at runtime
+RUN cp package.json dist/
+
 # Expose the API port
 EXPOSE 3420
 


### PR DESCRIPTION
## Problem

The 0.3.31 Docker image crashes with:
```
Error: ENOENT: no such file or directory, open '/app/dist/package.json'
```

## Cause

The `version.ts` file (added in #42) reads `package.json` relative to `__dirname`:
```ts
readFileSync(join(__dirname, '../package.json'), 'utf-8')
```

When bundled with tsup, `__dirname` resolves to `/app/dist`, so it looks for `/app/dist/../package.json` which should work... but tsup's bundling changes path resolution.

## Fix

Copy `package.json` to `dist/` after building so it's available at runtime.