### PR TITLE
fix: use process.cwd() for package.json path in version.ts

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -3,8 +3,10 @@ import { join } from 'path'
 
 // Read version from package.json at startup. Using readFileSync since this
 // runs once at import time, not per-request.
+// Use process.cwd() instead of __dirname since bundlers like tsup change
+// __dirname resolution, but cwd is reliably /app in Docker.
 const pkg = JSON.parse(
-  readFileSync(join(__dirname, '../package.json'), 'utf-8')
+  readFileSync(join(process.cwd(), 'package.json'), 'utf-8')
 )
 
 export const version: string = pkg.version


### PR DESCRIPTION
## Problem

The 0.3.31 Docker image crashes with:
```
Error: ENOENT: no such file or directory, open '/app/dist/package.json'
```

## Cause

`version.ts` uses `__dirname` to resolve `package.json`, but tsup bundling changes how `__dirname` resolves at runtime.

## Fix

Use `process.cwd()` instead, which reliably resolves to `/app` in the Docker container (the WORKDIR).