### PR TITLE
fix indexer returning empty fallbacks on contracts that dont exist

### DIFF
--- a/src/formulas/formulas/contract/xion/treasury.test.ts
+++ b/src/formulas/formulas/contract/xion/treasury.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { ContractEnv } from '@/types'
+
+import { admin, all, feeConfig, grantConfigs, params } from './treasury'
+
+// Build a minimal env that returns "no stored state" for every key.
+// Anything the treasury formulas read (`get`, `getMap`, `getBalances`,
+// `getTransformationMatch`) resolves to `undefined`/empty, matching the
+// shape an indexer sees for a contract it has never indexed.
+const makeEmptyEnv = (
+  contractAddress = 'xion1jjztzhx3vm67a002y6s0af9kpzkzn0a87a2mvxetqekym0gqt63s2zjq7p'
+): ContractEnv =>
+  ({
+    contractAddress,
+    args: {},
+    get: vi.fn().mockResolvedValue(undefined),
+    getMap: vi.fn().mockResolvedValue(undefined),
+    getBalances: vi.fn().mockResolvedValue(undefined),
+    getTransformationMatch: vi.fn().mockResolvedValue(undefined),
+    getExtraction: vi.fn().mockResolvedValue(undefined),
+  } as unknown as ContractEnv)
+
+describe('xion/treasury formulas — defensive emptiness checks', () => {
+  it('all.compute throws for an unindexed contract instead of returning the all-defaults shape', async () => {
+    await expect(all.compute(makeEmptyEnv())).rejects.toThrow(
+      'treasury not found'
+    )
+  })
+
+  it.each([
+    ['grantConfigs', grantConfigs],
+    ['feeConfig', feeConfig],
+    ['admin', admin],
+    ['params', params],
+  ])('%s.compute throws for an unindexed contract', async (_name, formula) => {
+    await expect(formula.compute(makeEmptyEnv())).rejects.toThrow(
+      'treasury not found'
+    )
+  })
+
+  it('all.compute returns the populated shape when admin is set', async () => {
+    const env = {
+      contractAddress: 'xion1real',
+      args: {},
+      get: vi.fn((_addr: string, key: string) => {
+        if (key === 'admin') {
+          return Promise.resolve({ valueJson: 'xion1admin' })
+        }
+        if (key === 'fee_config') {
+          return Promise.resolve({
+            valueJson: { allowance: { basic: { spend_limit: [] } } },
+          })
+        }
+        if (key === 'params') {
+          return Promise.resolve({ valueJson: { redirect_url: 'https://x' } })
+        }
+        return Promise.resolve(undefined)
+      }),
+      getMap: vi.fn().mockResolvedValue({
+        '/cosmos.bank.v1beta1.MsgSend': { authorization: {} },
+      }),
+      getBalances: vi.fn().mockResolvedValue({ uxion: '1000' }),
+      getTransformationMatch: vi.fn().mockResolvedValue(undefined),
+      getExtraction: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ContractEnv
+
+    const result = await all.compute(env)
+    expect(result.admin).toBe('xion1admin')
+    expect(result.grantConfigs).toMatchObject({
+      '/cosmos.bank.v1beta1.MsgSend': { authorization: {} },
+    })
+    expect(result.balances).toEqual({ uxion: '1000' })
+  })
+})

--- a/src/formulas/formulas/contract/xion/treasury.ts
+++ b/src/formulas/formulas/contract/xion/treasury.ts
@@ -63,6 +63,25 @@ const TreasuryStorageKeys = {
   PARAMS: 'params',
 }
 
+// A real treasury must have `admin` set: the contract's instantiate
+// (contracts/contracts/treasury/src/contract.rs:18-22) rejects `None` admin.
+// If admin is absent, the contract is either not a treasury or was never
+// indexed — throw so callers fall back to a direct chain query instead of
+// caching an empty placeholder.
+//
+// So this check is here purely to figure out if the indexer is returning a real
+// existing treasury, or just placeholder data for a non-existent one.
+const assertTreasuryIndexed = async (
+  env: Parameters<ContractFormula['compute']>[0]
+): Promise<void> => {
+  const adminValue = (
+    await env.get<Addr>(env.contractAddress, TreasuryStorageKeys.ADMIN)
+  )?.valueJson
+  if (adminValue === null || adminValue === undefined) {
+    throw new Error('treasury not found')
+  }
+}
+
 export const grantConfigs: ContractFormula<Record<string, GrantConfig>> = {
   docs: {
     description: "Get the treasury's grant configs by msg type url",
@@ -70,6 +89,8 @@ export const grantConfigs: ContractFormula<Record<string, GrantConfig>> = {
   },
   compute: async (env) => {
     const { contractAddress, getMap } = env
+
+    await assertTreasuryIndexed(env)
 
     return (
       (await getMap<string, GrantConfig>(
@@ -90,6 +111,8 @@ export const feeConfig: ContractFormula<FeeConfig | null> = {
   compute: async (env) => {
     const { contractAddress, get } = env
 
+    await assertTreasuryIndexed(env)
+
     return (
       (await get<FeeConfig>(contractAddress, TreasuryStorageKeys.FEE_CONFIG))
         ?.valueJson ?? null
@@ -105,10 +128,15 @@ export const admin: ContractFormula<Addr | null> = {
   compute: async (env) => {
     const { contractAddress, get } = env
 
-    return (
+    const adminValue =
       (await get<Addr>(contractAddress, TreasuryStorageKeys.ADMIN))
         ?.valueJson ?? null
-    )
+
+    if (adminValue === null || adminValue === undefined) {
+      throw new Error('treasury not found')
+    }
+
+    return adminValue
   },
 }
 
@@ -128,6 +156,8 @@ export const params: ContractFormula<Record<string, Params>> = {
   },
   compute: async (env) => {
     const { contractAddress, get } = env
+
+    await assertTreasuryIndexed(env)
 
     return (
       (await get<Params>(contractAddress, TreasuryStorageKeys.PARAMS))


### PR DESCRIPTION
changes the behaviour of the xion treasury indexer to return a fail instead of a empty response when a treasury contract doesnt exist.

as empty != non-indexed or non existent.