### PR TITLE
Apply contract state recovery feedback improvements

### DIFF
--- a/src/server/routes/indexer/contractState.ts
+++ b/src/server/routes/indexer/contractState.ts
@@ -40,7 +40,20 @@ type ContractStateDeps = {
 const getQueryString = (value: unknown): string | undefined =>
   typeof value === 'string' ? value : undefined
 
-export const createGetContractState =
+const isAuthorized = (authorization: string | undefined, password: string) => {
+  const [type, credentials] = authorization?.split(' ') ?? []
+  if (type !== 'Basic' || !credentials) {
+    return false
+  }
+
+  const [name, pass] = Buffer.from(credentials, 'base64').toString().split(':')
+  return name === 'exporter' && pass === password
+}
+
+const isRpcError = (message: string): boolean =>
+  /rpc|query|network|timeout|connection|fetch|request/i.test(message)
+
+export const createRecoverContractState =
   ({
     loadConfig,
     connect,
@@ -55,6 +68,18 @@ export const createGetContractState =
   async (ctx) => {
     const config = loadConfig()
     const address = ctx.params.address
+
+    if (
+      !isAuthorized(
+        ctx.header.authorization,
+        config.exporterDashboardPassword || 'exporter'
+      )
+    ) {
+      ctx.status = 401
+      ctx.set('WWW-Authenticate', 'Basic realm="contract-state-recovery"')
+      ctx.body = { error: 'authentication required' }
+      return
+    }
 
     try {
       const decoded = fromBech32(address)
@@ -121,7 +146,7 @@ export const createGetContractState =
         })
       } catch (err) {
         const message = err instanceof Error ? err.message : `${err}`
-        ctx.status = 500
+        ctx.status = isRpcError(message) ? 502 : 500
         ctx.body = { error: message }
         return
       }
@@ -144,7 +169,7 @@ export const createGetContractState =
     }
   }
 
-export const getContractState = createGetContractState({
+export const recoverContractStateHandler = createRecoverContractState({
   loadConfig: () => ConfigManager.load(),
   connect: CosmWasmClient.connect,
   recover: recoverContractState,

--- a/src/server/routes/indexer/index.ts
+++ b/src/server/routes/indexer/index.ts
@@ -2,7 +2,7 @@ import Router from '@koa/router'
 
 import { loadAggregator } from './aggregator'
 import { loadComputer } from './computer'
-import { getContractState } from './contractState'
+import { recoverContractStateHandler } from './contractState'
 import { getStatus } from './getStatus'
 import { up } from './up'
 
@@ -20,7 +20,10 @@ export const setUpIndexerRouter = async (root: Router) => {
   indexerRouter.get('/a/(.+)', aggregator)
 
   // Recover live CosmWasm contract storage through the events pipeline.
-  indexerRouter.post('/contract/:address/state/recover', getContractState)
+  indexerRouter.post(
+    '/contract/:address/state/recover',
+    recoverContractStateHandler
+  )
 
   // Formula computer. This must be the last route since it's a catch-all.
   const computer = await loadComputer()

--- a/src/server/test/indexer/contractState.test.ts
+++ b/src/server/test/indexer/contractState.test.ts
@@ -5,7 +5,7 @@ import request from 'supertest'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ConfigManager } from '@/config'
-import { createGetContractState } from '@/server/routes/indexer/contractState'
+import { createRecoverContractState } from '@/server/routes/indexer/contractState'
 
 const config = {
   ...ConfigManager.load(),
@@ -22,13 +22,19 @@ const recover = vi.fn()
 const fetchPage = vi.fn()
 const getContractInfo = vi.fn()
 const disconnect = vi.fn()
+const auth = Buffer.from('exporter:exporter').toString('base64')
+
+const recoverRequest = (app: Koa, address = validAddress, query = '') =>
+  request(app.callback())
+    .post(`/contract/${address}/state/recover${query}`)
+    .set('Authorization', `Basic ${auth}`)
 
 const makeApp = () => {
   const app = new Koa()
   const router = new Router()
   router.post(
     '/contract/:address/state/recover',
-    createGetContractState({
+    createRecoverContractState({
       loadConfig,
       connect,
       recover,
@@ -60,20 +66,23 @@ describe('POST /contract/:address/state/recover', () => {
     fetchPage.mockReturnValue(vi.fn())
   })
 
-  it('recovers live state through the events pipeline from remote RPC by default', async () => {
+  it('requires basic auth', async () => {
     await request(makeApp().callback())
       .post(`/contract/${validAddress}/state/recover`)
-      .expect(200)
-      .expect({
-        chainId: 'juno-1',
-        contractAddress: validAddress,
-        rpc: 'remote',
-        blockHeight: '123',
-        blockTimeUnixMs: '456000',
-        count: 1,
-        events: 1,
-        transformations: 1,
-      })
+      .expect(401)
+  })
+
+  it('recovers live state through the events pipeline from remote RPC by default', async () => {
+    await recoverRequest(makeApp()).expect(200).expect({
+      chainId: 'juno-1',
+      contractAddress: validAddress,
+      rpc: 'remote',
+      blockHeight: '123',
+      blockTimeUnixMs: '456000',
+      count: 1,
+      events: 1,
+      transformations: 1,
+    })
 
     expect(connect).toHaveBeenCalledWith(config.remoteRpc)
     expect(recover).toHaveBeenCalledWith({
@@ -90,17 +99,13 @@ describe('POST /contract/:address/state/recover', () => {
   it('disconnects the client when the state recovery fails', async () => {
     recover.mockRejectedValueOnce(new Error('database down'))
 
-    await request(makeApp().callback())
-      .post(`/contract/${validAddress}/state/recover`)
-      .expect(500)
+    await recoverRequest(makeApp()).expect(500)
 
     expect(disconnect).toHaveBeenCalledTimes(1)
   })
 
   it('rejects a wrong address prefix', async () => {
-    await request(makeApp().callback())
-      .post(`/contract/${wrongPrefixAddress}/state/recover`)
-      .expect(400)
+    await recoverRequest(makeApp(), wrongPrefixAddress).expect(400)
   })
 
   it('rejects local RPC when localRpc is not configured', async () => {
@@ -109,24 +114,18 @@ describe('POST /contract/:address/state/recover', () => {
       localRpc: undefined,
     })
 
-    await request(makeApp().callback())
-      .post(`/contract/${validAddress}/state/recover?rpc=local`)
-      .expect(400)
+    await recoverRequest(makeApp(), validAddress, '?rpc=local').expect(400)
   })
 
   it('maps internal recovery failures to 500', async () => {
     recover.mockRejectedValueOnce(new Error('database down'))
 
-    await request(makeApp().callback())
-      .post(`/contract/${validAddress}/state/recover`)
-      .expect(500)
+    await recoverRequest(makeApp()).expect(500)
   })
 
   it('maps RPC query failures to 502', async () => {
     getContractInfo.mockRejectedValueOnce(new Error('rpc down'))
 
-    await request(makeApp().callback())
-      .post(`/contract/${validAddress}/state/recover`)
-      .expect(502)
+    await recoverRequest(makeApp()).expect(502)
   })
 })

--- a/src/services/contract-state-dump.ts
+++ b/src/services/contract-state-dump.ts
@@ -16,16 +16,16 @@ export type FetchPageArgs = {
 }
 export type FetchPageResult = { models: RawModel[]; nextKey?: Uint8Array }
 
-export const fetchContractStatePage =
-  (client: CosmWasmClient) =>
-  async ({
+export const fetchContractStatePage = (client: CosmWasmClient) => {
+  const rpcClient = createProtobufRpcClient(
+    new QueryClient(client['forceGetCometClient']())
+  )
+
+  return async ({
     address,
     pageLimit,
     nextKey,
   }: FetchPageArgs): Promise<FetchPageResult> => {
-    const rpcClient = createProtobufRpcClient(
-      new QueryClient(client['forceGetCometClient']())
-    )
     const responseBytes = await rpcClient.request(
       'cosmwasm.wasm.v1.Query',
       'AllContractState',
@@ -47,6 +47,7 @@ export const fetchContractStatePage =
       nextKey: response.pagination?.nextKey,
     }
   }
+}
 
 export const dumpContractState = async ({
   address,

--- a/src/services/contract-state-recovery.ts
+++ b/src/services/contract-state-recovery.ts
@@ -1,5 +1,5 @@
 import { fromUtf8 } from '@cosmjs/encoding'
-import { Sequelize } from 'sequelize'
+import { Op, Sequelize } from 'sequelize'
 
 import { Block, Contract, State, WasmStateEvent } from '@/db'
 import { transformParsedStateEvents } from '@/transformers'
@@ -26,6 +26,9 @@ type RecoverContractStateDeps = {
   getLatestEvent?: (
     event: ParsedWasmStateEvent
   ) => Promise<LatestStateEvent | null>
+  getLatestEvents?: (
+    events: ParsedWasmStateEvent[]
+  ) => Promise<Map<string, LatestStateEvent>>
   saveEvents?: (
     events: ParsedWasmStateEvent[]
   ) => Promise<{ contract?: Contract }[]>
@@ -64,6 +67,7 @@ export const recoverContractState = async ({
   fetchPage,
   ensureContract = defaultEnsureContract,
   getLatestEvent = defaultGetLatestEvent,
+  getLatestEvents,
   saveEvents = defaultSaveEvents,
   transformEvents = transformParsedStateEvents,
   updateState = defaultUpdateState,
@@ -112,9 +116,18 @@ export const recoverContractState = async ({
     return { count: 0, events: 0, transformations: 0 }
   }
 
+  let latestEvents: Map<string, LatestStateEvent> | undefined
+  if (getLatestEvents) {
+    latestEvents = await getLatestEvents(events)
+  } else if (getLatestEvent === defaultGetLatestEvent) {
+    latestEvents = await defaultGetLatestEvents(events)
+  }
+
   const eventsToSave: ParsedWasmStateEvent[] = []
   for (const event of events) {
-    const latestEvent = await getLatestEvent(event)
+    const latestEvent = latestEvents
+      ? latestEvents.get(stateEventKey(event))
+      : await getLatestEvent(event)
     if (!latestEvent || !isUnchangedLiveState(event, latestEvent)) {
       eventsToSave.push(event)
     }
@@ -196,6 +209,12 @@ export const defaultEnsureContract = async ({
   )
 }
 
+const stateEventKey = ({
+  contractAddress,
+  key,
+}: Pick<ParsedWasmStateEvent, 'contractAddress' | 'key'>) =>
+  `${contractAddress}:${key}`
+
 export const defaultGetLatestEvent = async ({
   contractAddress,
   key,
@@ -208,6 +227,31 @@ export const defaultGetLatestEvent = async ({
     order: [['blockHeight', 'DESC']],
     attributes: ['value', 'valueJson', 'delete'],
   })
+
+export const defaultGetLatestEvents = async (
+  events: ParsedWasmStateEvent[]
+): Promise<Map<string, LatestStateEvent>> => {
+  const addresses = [...new Set(events.map((event) => event.contractAddress))]
+  const keys = [...new Set(events.map((event) => event.key))]
+  const latestEvents = await WasmStateEvent.findAll({
+    where: {
+      contractAddress: { [Op.in]: addresses },
+      key: { [Op.in]: keys },
+    },
+    order: [['blockHeight', 'DESC']],
+    attributes: ['contractAddress', 'key', 'value', 'valueJson', 'delete'],
+  })
+
+  const latestEventMap = new Map<string, LatestStateEvent>()
+  latestEvents.forEach((event) => {
+    const key = stateEventKey(event)
+    if (!latestEventMap.has(key)) {
+      latestEventMap.set(key, event)
+    }
+  })
+
+  return latestEventMap
+}
 
 export const defaultSaveEvents = async (events: ParsedWasmStateEvent[]) => {
   const savedEvents = await WasmStateEvent.bulkCreate(events, {

--- a/src/tracer/handlers/wasm.ts
+++ b/src/tracer/handlers/wasm.ts
@@ -27,11 +27,21 @@ export const scheduleDelayedContractStateRecoveries = async (
   contractEvents: DelayedContractStateRecoveryEvent[],
   addDelayed: typeof ContractStateRecoveryQueue.addDelayed = ContractStateRecoveryQueue.addDelayed
 ) => {
-  await Promise.all(
+  const results = await Promise.allSettled(
     contractEvents.map(({ address, blockHeight }) =>
       addDelayed({ address, detectedBlockHeight: blockHeight })
     )
   )
+
+  results.forEach((result, index) => {
+    if (result.status === 'rejected') {
+      const { address, blockHeight } = contractEvents[index]
+      console.error(
+        `failed to enqueue contract state recovery for ${address} at ${blockHeight}:`,
+        result.reason
+      )
+    }
+  })
 }
 
 export { CONTRACT_STATE_RECOVERY_DELAY_MS }


### PR DESCRIPTION
## Summary

Copies the contract state recovery/API review-feedback improvements from the Burnt fork PR back upstream.

Changes:
- Batch latest-event lookup in contract state recovery to avoid the default N+1 query path.
- Reuse the protobuf RPC client across paginated contract state RPC reads.
- Make delayed recovery queue enqueueing best-effort so BullMQ/Redis failures do not abort wasm export processing.
- Protect the recovery endpoint with exporter basic auth and add an unauthenticated-access regression test.
- Rename recovery route handler exports to reflect the POST side effect.
- Return 502 for recovery-time RPC/query/network errors while keeping internal recovery failures as 500.

## Validation

- `NODE_ENV=development npm ci --include=dev --ignore-scripts`, then `./node_modules/.bin/patch-package`
- `NODE_ENV=development npm run lint` — PASS
- `NODE_ENV=development npm run build` — PASS, existing CommonJS migration warnings only
- `CONFIG_FILE=config-test.json NODE_ENV=test npx vitest run src/services/contract-state-dump.test.ts src/services/contract-state-recovery.test.ts src/queues/queues/contract-state-recovery.test.ts src/tracer/handlers/wasm.delayed-recovery.test.ts src/server/test/indexer/contractState.test.ts --config vitest.config.mts --no-file-parallelism` — PASS, 18 tests
