### PR TITLE
Fix Infisical token renewal command

### DIFF
--- a/infisical-renew.sh
+++ b/infisical-renew.sh
@@ -2,10 +2,11 @@
 
 echo "🔄 Renewing token at $(date)..."
 
-# get the token from the .env file
+# Get the token from the .env file.
 INFISICAL_TOKEN=$(grep '^INFISICAL_TOKEN=' .env | cut -d '=' -f 2)
 
-NEW_TOKEN=$(npx @infisical/cli token renew $INFISICAL_TOKEN | grep '^ey')
+# Infisical CLI >=0.43 renews identity tokens with `token renew`.
+NEW_TOKEN=$(npx @infisical/cli token renew "$INFISICAL_TOKEN" | grep '^ey')
 
 if [ -z "$NEW_TOKEN" ]; then
   echo "❌ Failed to renew token at $(date)"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "pre-compute": "node dist/scripts/preCompute.js",
     "revalidate": "node dist/scripts/revalidate.js",
     "flood": "node dist/scripts/flood.js",
-    "renew-infisical-token": "npx @infisical/cli renew --token $INFISICAL_TOKEN --projectId $INFISICAL_PROJECT_ID --env $INFISICAL_ENVIRONMENT",
+    "renew-infisical-token": "sh infisical-renew.sh",
     "serve": "node dist/server/serve.js",
     "serve:dev": "docker compose -f compose.dev.yml up",
     "serve:dev:nodocker": "nodemon --watch dist --signal SIGTERM --exec \"node dist/server/serve.js\"",


### PR DESCRIPTION
## Purpose
Update the source-controlled Infisical renewal automation so indexer deployments remain compatible with current Infisical CLI versions. Infisical CLI 0.43+ renews identity tokens with `token renew`, so this prevents renewal failures caused by the removed legacy `renew` command.

## Changes
- Route both renewal npm scripts through the shared `infisical-renew.sh` script.
- Ensure the renewal script calls `npx @infisical/cli token renew` with the current token.
- Add a short comment documenting the CLI command compatibility.

## Verification
- Ran `sh -n infisical-renew.sh`.
- Verified `package.json` renewal scripts point to `sh infisical-renew.sh`.
- Grepped tracked files for stale `infisical renew` / `@infisical/cli renew` usage.
- Confirmed `npx @infisical/cli token renew --help` is available without secrets.
