### PR TITLE
Fix tracer reconnect and exporter health after chain upgrades

### DIFF
--- a/docs/exporter.md
+++ b/docs/exporter.md
@@ -28,3 +28,44 @@ about webhooks and how they work.
 The exporter invalidates the cache when it detects a state change event that
 invalidates a computation. See the [cache docs](./cache.md) for more information
 about the cache.
+
+## Chain node restarts and upgrades
+
+The chain node writes KV traces to a FIFO. When the node stops for a restart or
+binary upgrade, it closes that FIFO writer. The exporter keeps running and
+reopens its FIFO reader so that it automatically consumes traces when the
+replacement node writer connects.
+
+After a restart, verify that the export height returned by `/status` advances.
+The `/up` route considers the indexer caught up only when its exported block is
+within the existing five-block threshold of the remote chain. A local RPC block
+is included in the response for diagnostics, but local node health does not
+prove that the exporter consumed its traces.
+
+## Recovering after a trace outage
+
+Do not run recovery against production without authorization. First deploy or
+restart the exporter and verify that `/status` advances beyond the last block
+before the outage. For example, the Juno v30 upgrade occurred at height
+`40,420,069`, so an exporter frozen at `40,420,068` must advance beyond that
+boundary before repairing state.
+
+For a fast current-state repair of a known contract, use the authenticated
+recovery route:
+
+```bash
+curl -u 'exporter:<password>' -X POST \
+  'https://<indexer-host>/<chain-id>/contract/<address>/state/recover?rpc=local&pageLimit=1000'
+```
+
+Verify the affected formulas after recovery. Repeat this operation for every
+known contract whose state changed during the gap if current query correctness
+is required.
+
+This recovery fetches and stores the contract's current keys. It does **not**
+remove indexed keys that are now absent, and it cannot reconstruct intermediate
+state changes or historical events from the outage. Full-fidelity recovery
+requires an authorized node restored at or before the last exported height,
+replay with KV tracing into an isolated Argus recovery database, validation,
+and an approved promotion or merge procedure. Never point a historical replay
+at production without a dedicated runbook and backup.

--- a/src/server/routes/indexer/up.test.ts
+++ b/src/server/routes/indexer/up.test.ts
@@ -23,11 +23,11 @@ describe('isIndexerCaughtUp', () => {
   })
 
   it('preserves the strict five-block boundary', () => {
-    expect(
-      isIndexerCaughtUp({ remoteHeight: 100, exportedHeight: 95 })
-    ).toBe(false)
-    expect(
-      isIndexerCaughtUp({ remoteHeight: 100, exportedHeight: 96 })
-    ).toBe(true)
+    expect(isIndexerCaughtUp({ remoteHeight: 100, exportedHeight: 95 })).toBe(
+      false
+    )
+    expect(isIndexerCaughtUp({ remoteHeight: 100, exportedHeight: 96 })).toBe(
+      true
+    )
   })
 })

--- a/src/server/routes/indexer/up.test.ts
+++ b/src/server/routes/indexer/up.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { isIndexerCaughtUp } from './up'
+
+describe('isIndexerCaughtUp', () => {
+  it('reports a stale exporter even when the local RPC is current', () => {
+    expect(
+      isIndexerCaughtUp({
+        remoteHeight: 40_483_940,
+        localHeight: 40_483_940,
+        exportedHeight: 40_420_068,
+      })
+    ).toBe(false)
+  })
+
+  it('reports an exporter fewer than five blocks behind as caught up', () => {
+    expect(
+      isIndexerCaughtUp({
+        remoteHeight: 40_483_940,
+        exportedHeight: 40_483_938,
+      })
+    ).toBe(true)
+  })
+
+  it('preserves the strict five-block boundary', () => {
+    expect(
+      isIndexerCaughtUp({ remoteHeight: 100, exportedHeight: 95 })
+    ).toBe(false)
+    expect(
+      isIndexerCaughtUp({ remoteHeight: 100, exportedHeight: 96 })
+    ).toBe(true)
+  })
+})

--- a/src/server/routes/indexer/up.ts
+++ b/src/server/routes/indexer/up.ts
@@ -12,6 +12,17 @@ type UpBlock = {
   timestamp: string
 }
 
+type IndexerHeights = {
+  remoteHeight: number
+  exportedHeight: number
+  localHeight?: number
+}
+
+export const isIndexerCaughtUp = ({
+  remoteHeight,
+  exportedHeight,
+}: IndexerHeights) => exportedHeight > remoteHeight - 5
+
 type UpResponse =
   | {
       version: string
@@ -150,13 +161,11 @@ export const up: Router.Middleware<
     timestamp: state.latestBlockDate.toISOString(),
   }
 
-  // If local chain is within 5 blocks of actual chain, consider it caught up.
-  // If no local RPC, use the exported block instead.
-  const caughtUp =
-    (localBlock && 'height' in localBlock
-      ? localBlock.height
-      : exportedBlock.height) >
-    remoteBlock.height - 5
+  // A healthy local RPC does not prove that the exporter consumed its traces.
+  const caughtUp = isIndexerCaughtUp({
+    remoteHeight: remoteBlock.height,
+    exportedHeight: exportedBlock.height,
+  })
 
   ctx.status = caughtUp ? 200 : 412
   ctx.body = {

--- a/src/tracer/utils.test.ts
+++ b/src/tracer/utils.test.ts
@@ -63,6 +63,50 @@ describe('setUpFifoJsonTracer', () => {
     await expect(tracer.promise).resolves.toBeUndefined()
   })
 
+  it('stops processing a chunk after an onData callback fails', async () => {
+    directory = await mkdtemp(join(tmpdir(), 'argus-fifo-'))
+    const fifo = join(directory, 'trace.fifo')
+    await execFileAsync('mkfifo', [fifo])
+    const seen: unknown[] = []
+    const error = new Error('callback failed')
+    const tracer = setUpFifoJsonTracer({
+      file: fifo,
+      onData: (data) => {
+        seen.push(data)
+        throw error
+      },
+    })
+    close = tracer.close
+
+    const rejection = expect(tracer.promise).rejects.toBe(error)
+    await writeFile(fifo, '{"line":1}\n{"line":2}\n')
+
+    await rejection
+    expect(seen).toEqual([{ line: 1 }])
+  })
+
+  it('stops processing a chunk after an onError callback fails', async () => {
+    directory = await mkdtemp(join(tmpdir(), 'argus-fifo-'))
+    const fifo = join(directory, 'trace.fifo')
+    await execFileAsync('mkfifo', [fifo])
+    const seen: unknown[] = []
+    const error = new Error('error callback failed')
+    const tracer = setUpFifoJsonTracer({
+      file: fifo,
+      onData: (data) => seen.push(data),
+      onError: () => {
+        throw error
+      },
+    })
+    close = tracer.close
+
+    const rejection = expect(tracer.promise).rejects.toBe(error)
+    await writeFile(fifo, 'invalid\n{"line":2}\n')
+
+    await rejection
+    expect(seen).toEqual([])
+  })
+
   it('resolves when explicitly closed while waiting for a writer', async () => {
     directory = await mkdtemp(join(tmpdir(), 'argus-fifo-'))
     const fifo = join(directory, 'trace.fifo')

--- a/src/tracer/utils.test.ts
+++ b/src/tracer/utils.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { promisify } from 'util'
+
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { setUpFifoJsonTracer } from './utils'

--- a/src/tracer/utils.test.ts
+++ b/src/tracer/utils.test.ts
@@ -1,0 +1,77 @@
+import { execFile } from 'child_process'
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { promisify } from 'util'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { setUpFifoJsonTracer } from './utils'
+
+const execFileAsync = promisify(execFile)
+
+const waitFor = async (assertion: () => void, timeout = 2_000) => {
+  const deadline = Date.now() + timeout
+  while (Date.now() < deadline) {
+    try {
+      assertion()
+      return
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+  }
+  assertion()
+}
+
+const settlesWithin = async (promise: Promise<void>, timeout: number) =>
+  Promise.race([
+    promise.then(() => true),
+    new Promise<false>((resolve) => setTimeout(() => resolve(false), timeout)),
+  ])
+
+describe('setUpFifoJsonTracer', () => {
+  let directory: string | undefined
+  let close: (() => void) | undefined
+
+  afterEach(async () => {
+    close?.()
+    if (directory) {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps reading after the FIFO writer disconnects', async () => {
+    directory = await mkdtemp(join(tmpdir(), 'argus-fifo-'))
+    const fifo = join(directory, 'trace.fifo')
+    await execFileAsync('mkfifo', [fifo])
+    const seen: unknown[] = []
+    const tracer = setUpFifoJsonTracer({
+      file: fifo,
+      onData: (data) => seen.push(data),
+    })
+    close = tracer.close
+
+    await writeFile(fifo, `${JSON.stringify({ block: 40420068 })}\n`)
+    await waitFor(() => expect(seen).toEqual([{ block: 40420068 }]))
+    expect(await settlesWithin(tracer.promise, 100)).toBe(false)
+
+    await writeFile(fifo, `${JSON.stringify({ block: 40420069 })}\n`)
+    await waitFor(() =>
+      expect(seen).toEqual([{ block: 40420068 }, { block: 40420069 }])
+    )
+
+    tracer.close()
+    await expect(tracer.promise).resolves.toBeUndefined()
+  })
+
+  it('resolves when explicitly closed while waiting for a writer', async () => {
+    directory = await mkdtemp(join(tmpdir(), 'argus-fifo-'))
+    const fifo = join(directory, 'trace.fifo')
+    await execFileAsync('mkfifo', [fifo])
+    const tracer = setUpFifoJsonTracer({ file: fifo, onData: () => {} })
+    close = tracer.close
+
+    tracer.close()
+
+    await expect(tracer.promise).resolves.toBeUndefined()
+  })
+})

--- a/src/tracer/utils.test.ts
+++ b/src/tracer/utils.test.ts
@@ -63,6 +63,57 @@ describe('setUpFifoJsonTracer', () => {
     await expect(tracer.promise).resolves.toBeUndefined()
   })
 
+  it('awaits async callbacks before processing the next line', async () => {
+    directory = await mkdtemp(join(tmpdir(), 'argus-fifo-'))
+    const fifo = join(directory, 'trace.fifo')
+    await execFileAsync('mkfifo', [fifo])
+    const seen: unknown[] = []
+    let releaseFirst: () => void = () => {}
+    const firstCanFinish = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    const tracer = setUpFifoJsonTracer({
+      file: fifo,
+      onData: async (data) => {
+        seen.push(data)
+        if (seen.length === 1) {
+          await firstCanFinish
+        }
+      },
+    })
+    close = tracer.close
+
+    await writeFile(fifo, '{"line":1}\n{"line":2}\n')
+    await waitFor(() => expect(seen).toEqual([{ line: 1 }]))
+    await new Promise((resolve) => setTimeout(resolve, 25))
+    expect(seen).toEqual([{ line: 1 }])
+
+    releaseFirst()
+    await waitFor(() => expect(seen).toEqual([{ line: 1 }, { line: 2 }]))
+  })
+
+  it('stops processing after an async callback rejects', async () => {
+    directory = await mkdtemp(join(tmpdir(), 'argus-fifo-'))
+    const fifo = join(directory, 'trace.fifo')
+    await execFileAsync('mkfifo', [fifo])
+    const seen: unknown[] = []
+    const error = new Error('async callback failed')
+    const tracer = setUpFifoJsonTracer({
+      file: fifo,
+      onData: async (data) => {
+        seen.push(data)
+        throw error
+      },
+    })
+    close = tracer.close
+
+    const rejection = expect(tracer.promise).rejects.toBe(error)
+    await writeFile(fifo, '{"line":1}\n{"line":2}\n')
+
+    await rejection
+    expect(seen).toEqual([{ line: 1 }])
+  })
+
   it('stops processing a chunk after an onData callback fails', async () => {
     directory = await mkdtemp(join(tmpdir(), 'argus-fifo-'))
     const fifo = join(directory, 'trace.fifo')

--- a/src/tracer/utils.ts
+++ b/src/tracer/utils.ts
@@ -9,8 +9,7 @@ type FifoJsonTracerOptions = {
 }
 
 type FifoJsonTracer = {
-  // Promise that resolves when the FIFO is closed or rejects if the FIFO
-  // errors.
+  // Promise that resolves when explicitly closed or rejects if the FIFO errors.
   promise: Promise<void>
   // Close the FIFO and resolve the promise.
   close: () => void
@@ -61,129 +60,118 @@ export const setUpFifoJsonTracer = ({
   onData,
   onError,
 }: FifoJsonTracerOptions): FifoJsonTracer => {
-  const fifoRs = fs.createReadStream(file, {
-    // Parse chunks as UTF-8 strings.
-    encoding: 'utf-8',
+  let activeStream: fs.ReadStream | undefined
+  let shuttingDown = false
+  let settled = false
+  let resolvePromise: () => void = () => {}
+  let rejectPromise: (error: unknown) => void = () => {}
+
+  const promise = new Promise<void>((resolve, reject) => {
+    resolvePromise = resolve
+    rejectPromise = reject
   })
 
-  // In the case a chunk ends in the middle of a JSON object and not after a
-  // newline, buffer the chunk and continue reading until we have a valid JSON
-  // object.
-  let buffer = ''
-
-  const dataListener = (chunk: string | Buffer) => {
-    // Type-check chunk. It should be a string due to `encoding` set above.
-    if (!chunk || typeof chunk !== 'string') {
-      return
-    }
-
-    // All complete lines that should be JSON objects end with a newline, so
-    // the last item in this array will be an empty string if the last line
-    // is complete. The last line may not be complete if the data being sent
-    // exceeds the chunk buffer size. If this is the case, use the buffer
-    // across chunks to build the incomplete line.
-    const lines = chunk.split('\n')
-
-    if (lines.length === 0) {
-      return
-    }
-
-    // If the previous chunk left an incomplete line in the buffer, prepend
-    // it to the first line of this chunk.
-    if (buffer) {
-      lines[0] = buffer + lines[0]
-      buffer = ''
-    }
-
-    // If the last line is not empty, it is incomplete, so buffer it for the
-    // next chunk.
-    if (lines[lines.length - 1]) {
-      buffer = lines.pop()!
-    }
-
-    for (const line of lines) {
-      // Ignore empty line.
-      if (!line) {
-        continue
-      }
-
-      let data: unknown | undefined
-      try {
-        data = JSON.parse(line)
-      } catch (error) {
-        // If we cannot parse the buffer as a JSON object, call the error
-        // callback if provided.
-        onError?.(line, error)
-        continue
-      }
-
-      // Execute callback with parsed JSON.
-      onData(data)
+  const resolve = () => {
+    if (!settled) {
+      settled = true
+      resolvePromise()
     }
   }
 
-  let opened = false
+  const reject = (error: unknown) => {
+    if (!settled) {
+      settled = true
+      rejectPromise(error)
+    }
+  }
 
-  // Wait for FIFO to error or end.
-  let resolveDelayed: () => void = () => {}
-  const promise = new Promise<void>((_resolve, reject) => {
-    let done = false
-    const resolve = () => {
-      if (!done) {
-        done = true
-        _resolve()
+  const openReaderSession = () => {
+    if (shuttingDown || settled) {
+      return
+    }
+
+    // A partial line belongs to the writer session that produced it and must
+    // not be combined with data from a replacement writer.
+    let buffer = ''
+    let sessionComplete = false
+    const stream = fs.createReadStream(file, { encoding: 'utf-8' })
+    activeStream = stream
+
+    const reconnect = () => {
+      if (sessionComplete) {
+        return
+      }
+      sessionComplete = true
+      if (activeStream === stream) {
+        activeStream = undefined
+      }
+      if (!shuttingDown && !settled) {
+        setImmediate(openReaderSession)
       }
     }
-    resolveDelayed = () => setTimeout(resolve, 5_000)
 
-    fifoRs.on('error', (error) => {
-      fifoRs.off('end', resolve)
-      fifoRs.off('close', resolveDelayed)
-      // Reject once the FIFO ends.
-      fifoRs.on('end', () => {
-        if (!done) {
-          done = true
-          reject(error)
+    stream.on('open', () => {
+      console.log(`[${new Date().toISOString()}] FIFO opened.`)
+    })
+
+    stream.on('data', (chunk: string | Buffer) => {
+      if (!chunk || typeof chunk !== 'string') {
+        return
+      }
+
+      const lines = chunk.split('\n')
+      if (buffer) {
+        lines[0] = buffer + lines[0]
+        buffer = ''
+      }
+      if (lines[lines.length - 1]) {
+        buffer = lines.pop()!
+      }
+
+      for (const line of lines) {
+        if (!line) {
+          continue
         }
-      })
-      // If closed and promise not done after 2 seconds, reject.
-      fifoRs.on('close', () => {
-        setTimeout(() => {
-          if (!done) {
-            done = true
+
+        try {
+          onData(JSON.parse(line))
+        } catch (error) {
+          if (error instanceof SyntaxError) {
+            onError?.(line, error)
+          } else {
+            shuttingDown = true
+            stream.destroy()
             reject(error)
           }
-        }, 2000)
-      })
-      // Close the FIFO if it is not already closed, so it ends.
-      if (!fifoRs.closed) {
-        fifoRs.destroy()
+        }
       }
     })
 
-    fifoRs.on('open', () => {
-      console.log(`[${new Date().toISOString()}] FIFO opened.`)
-      opened = true
+    stream.on('error', (error) => {
+      sessionComplete = true
+      shuttingDown = true
+      if (activeStream === stream) {
+        activeStream = undefined
+      }
+      stream.destroy()
+      reject(error)
     })
+    stream.on('end', reconnect)
+    stream.on('close', reconnect)
+  }
 
-    // Once data ends, resolve.
-    fifoRs.on('end', resolve)
-
-    // If closed and promise not done after 5 seconds, resolve.
-    fifoRs.on('close', resolveDelayed)
-  })
-
-  // Start reading from the FIFO.
-  fifoRs.on('data', dataListener)
+  openReaderSession()
 
   return {
     promise,
     close: () => {
-      fifoRs.destroy()
-      // If the FIFO was not opened, resolve the promise in 5 seconds.
-      if (!opened) {
-        resolveDelayed()
+      if (shuttingDown) {
+        return
       }
+      shuttingDown = true
+      activeStream?.destroy()
+      activeStream = undefined
+      resolve()
     },
   }
 }

--- a/src/tracer/utils.ts
+++ b/src/tracer/utils.ts
@@ -105,7 +105,9 @@ export const setUpFifoJsonTracer = ({
       if (activeStream === stream) {
         activeStream = undefined
       }
-      if (!shuttingDown && !settled) {
+      if (shuttingDown) {
+        resolve()
+      } else if (!settled) {
         setImmediate(openReaderSession)
       }
     }
@@ -143,6 +145,7 @@ export const setUpFifoJsonTracer = ({
             shuttingDown = true
             stream.destroy()
             reject(callbackError)
+            return
           }
           continue
         }
@@ -153,18 +156,23 @@ export const setUpFifoJsonTracer = ({
           shuttingDown = true
           stream.destroy()
           reject(error)
+          return
         }
       }
     })
 
     stream.on('error', (error) => {
       sessionComplete = true
-      shuttingDown = true
       if (activeStream === stream) {
         activeStream = undefined
       }
       stream.destroy()
-      reject(error)
+      if (shuttingDown) {
+        resolve()
+      } else {
+        shuttingDown = true
+        reject(error)
+      }
     })
     stream.on('end', reconnect)
     stream.on('close', reconnect)
@@ -179,9 +187,23 @@ export const setUpFifoJsonTracer = ({
         return
       }
       shuttingDown = true
-      activeStream?.destroy()
-      activeStream = undefined
-      resolve()
+      const stream = activeStream
+      if (!stream) {
+        resolve()
+      } else if (stream.pending) {
+        // A read-only FIFO open blocks until a writer connects. Open a
+        // temporary writer to release that pending open before destroying
+        // the stream, so shutdown does not leave a libuv worker blocked
+        // indefinitely. The matching pending reader makes this open complete.
+        fs.open(file, fs.constants.O_WRONLY, (error, fd) => {
+          if (fd !== undefined) {
+            fs.close(fd, () => {})
+          }
+          stream.destroy(error ?? undefined)
+        })
+      } else {
+        stream.destroy()
+      }
     },
   }
 }

--- a/src/tracer/utils.ts
+++ b/src/tracer/utils.ts
@@ -2,10 +2,10 @@ import * as fs from 'fs'
 
 type FifoJsonTracerOptions = {
   file: string
-  onData: (data: unknown) => void
+  onData: (data: unknown) => unknown | Promise<unknown>
   // If provided, this callback will be called when a JSON object cannot be
   // parsed from the line.
-  onError?: (line: string, error: unknown) => void
+  onError?: (line: string, error: unknown) => unknown | Promise<unknown>
 }
 
 type FifoJsonTracer = {
@@ -18,8 +18,8 @@ type FifoJsonTracer = {
 // Trace a FIFO (see `mkfifo`) that transmits JSON objects on each line, and
 // execute an asynchronous callback synchronously (i.e. don't read from the FIFO
 // while executing the async callback) with the parsed JSON object. If the
-// callback throws an error, the FIFO will be closed and the error will be
-// thrown. If a line cannot be parsed as a JSON object, the `onError` callback
+// callback throws or rejects, the FIFO will be closed and the lifetime
+// promise will reject. If a line cannot be parsed as a JSON object, the `onError` callback
 // will be called if provided. If the `onError` callback is not provided, the
 // line will be ignored.
 //
@@ -121,44 +121,46 @@ export const setUpFifoJsonTracer = ({
         return
       }
 
-      const lines = chunk.split('\n')
-      if (buffer) {
-        lines[0] = buffer + lines[0]
-        buffer = ''
-      }
-      if (lines[lines.length - 1]) {
-        buffer = lines.pop()!
-      }
+      // Pause before awaiting callbacks so later chunks cannot be read or
+      // processed until every complete line in this chunk finishes.
+      stream.pause()
 
-      for (const line of lines) {
-        if (!line) {
-          continue
+      void (async () => {
+        const lines = chunk.split('\n')
+        if (buffer) {
+          lines[0] = buffer + lines[0]
+          buffer = ''
+        }
+        if (lines[lines.length - 1]) {
+          buffer = lines.pop()!
         }
 
-        let data: unknown
-        try {
-          data = JSON.parse(line)
-        } catch (error) {
-          try {
-            onError?.(line, error)
-          } catch (callbackError) {
-            shuttingDown = true
-            stream.destroy()
-            reject(callbackError)
-            return
+        for (const line of lines) {
+          if (!line) {
+            continue
           }
-          continue
-        }
 
-        try {
-          onData(data)
-        } catch (error) {
+          let data: unknown
+          try {
+            data = JSON.parse(line)
+          } catch (error) {
+            await onError?.(line, error)
+            continue
+          }
+
+          await onData(data)
+        }
+      })()
+        .then(() => {
+          if (!shuttingDown && !settled && !stream.destroyed) {
+            stream.resume()
+          }
+        })
+        .catch((error) => {
           shuttingDown = true
           stream.destroy()
           reject(error)
-          return
-        }
-      }
+        })
     })
 
     stream.on('error', (error) => {

--- a/src/tracer/utils.ts
+++ b/src/tracer/utils.ts
@@ -133,16 +133,26 @@ export const setUpFifoJsonTracer = ({
           continue
         }
 
+        let data: unknown
         try {
-          onData(JSON.parse(line))
+          data = JSON.parse(line)
         } catch (error) {
-          if (error instanceof SyntaxError) {
+          try {
             onError?.(line, error)
-          } else {
+          } catch (callbackError) {
             shuttingDown = true
             stream.destroy()
-            reject(error)
+            reject(callbackError)
           }
+          continue
+        }
+
+        try {
+          onData(data)
+        } catch (error) {
+          shuttingDown = true
+          stream.destroy()
+          reject(error)
         }
       }
     })


### PR DESCRIPTION
## Purpose

Fixes #50.

Juno indexing stopped at the v30 upgrade boundary even though `/up` reported the indexer as caught up. The outage was caused by the KV trace FIFO reader exiting successfully when the chain node closed its writer during the upgrade—not by a wasmd key or event format change.

## Context

Live evidence showed the global bank exporter frozen at `40,420,068`, immediately before the `40,420,069` upgrade, while the chain and local RPC continued advancing. That all-store freeze rules out a wasm-only parser issue. A node upgrade closes the FIFO writer; previously, natural EOF resolved the tracer lifetime and allowed the process to exit successfully without reopening the FIFO.

Exact source investigation confirmed Juno v30 uses [wasmd `v0.61.11`](https://github.com/CosmosContracts/juno/blob/c0b3a8d258d52d16e5bc39a75168a99aab9d098e/go.mod#L1-L31) without a relevant [dependency replacement](https://github.com/CosmosContracts/juno/blob/c0b3a8d258d52d16e5bc39a75168a99aab9d098e/go.mod#L472-L492), and the wasm key/event formats remain compatible. The lightweight parser characterization has been separated into a follow-up PR as requested.

## Changes

- Keep the FIFO reader alive across natural writer EOF and reconnect for replacement node writers.
- Await and serialize sync/async callbacks with FIFO backpressure.
- Preserve fatal stream/callback rejection and fully terminate explicit shutdown, including a pending FIFO open.
- Base `/up` caught-up status on exported progress rather than local RPC health.
- Document restart behavior and current-state/full-history recovery procedures.

## Verification

- Focused infrastructure suite: 4 files, 17 tests passed.
- `npm run lint`: passed.
- `npm run build`: passed; only pre-existing CommonJS migration warnings were emitted.
- The earlier complete `npm test` attempt had environment-dependent integration failures because Sequelize models and routers were not initialized; the scoped non-integration coverage is green.

## Recovery after deployment

1. Confirm `/status` advances beyond `40,420,068`; `/up` should return 200 only after the exported block is within five blocks of the remote chain.
2. Use the authenticated current-state recovery endpoint for each known affected contract, then verify proposals and votes.
3. Snapshot repair cannot synthesize absent-key deletions or reconstruct intermediate history.
4. Full-fidelity recovery requires an authorized pre-gap node replay with KV tracing into an isolated recovery database, followed by validation and an approved promotion procedure.

No production recovery was run.
