### PR TITLE
Test Juno v30 wasm store key parsing

### DIFF
--- a/src/tracer/handlers/wasm.key.test.ts
+++ b/src/tracer/handlers/wasm.key.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseWasmStoreKey } from './wasm'
+
+describe('parseWasmStoreKey', () => {
+  it('parses a Juno v30 contract state key', () => {
+    const proposal42TraceKey =
+      'A5dHR/1jIwQddN2fdxZpDoG7YKst2MT51H4nrxvh3RhjAAxwcm9wb3NhbHNfdjIAAAAAAAAAKg=='
+
+    expect(parseWasmStoreKey(proposal42TraceKey, 'juno')).toEqual({
+      prefix: 0x03,
+      contractAddress:
+        'juno1jar50ltryvzp6axanam3v6gwsxakp2edmrz0n4r7y7h3hcwarp3sm6ccsp',
+      stateKey:
+        '0,12,112,114,111,112,111,115,97,108,115,95,118,50,0,0,0,0,0,0,0,42',
+    })
+  })
+
+  it('parses a Juno v30 contract info key', () => {
+    expect(
+      parseWasmStoreKey('ApdHR/1jIwQddN2fdxZpDoG7YKst2MT51H4nrxvh3Rhj', 'juno')
+    ).toEqual({
+      prefix: 0x02,
+      contractAddress:
+        'juno1jar50ltryvzp6axanam3v6gwsxakp2edmrz0n4r7y7h3hcwarp3sm6ccsp',
+      stateKey: '',
+    })
+  })
+
+  it('ignores a key too short to contain a contract address', () => {
+    expect(parseWasmStoreKey('Aw==', 'juno')).toBeUndefined()
+  })
+})

--- a/src/tracer/handlers/wasm.ts
+++ b/src/tracer/handlers/wasm.ts
@@ -17,6 +17,28 @@ import { dbKeyForKeys, getContractInfo, retry } from '@/utils'
 
 const STORE_NAME = 'wasm'
 const DEFAULT_CONTRACT_BYTE_LENGTH = 32
+const CONTRACT_KEY_PREFIX = 0x02
+const CONTRACT_STORE_PREFIX = 0x03
+
+export const parseWasmStoreKey = (key: string, bech32Prefix: string) => {
+  const keyData = fromBase64(key)
+  const prefix = keyData[0]
+  if (prefix !== CONTRACT_STORE_PREFIX && prefix !== CONTRACT_KEY_PREFIX) {
+    return
+  }
+  if (keyData.length < 1 + DEFAULT_CONTRACT_BYTE_LENGTH) {
+    return
+  }
+
+  return {
+    prefix,
+    contractAddress: toBech32(
+      bech32Prefix,
+      keyData.slice(1, 1 + DEFAULT_CONTRACT_BYTE_LENGTH)
+    ),
+    stateKey: keyData.slice(1 + DEFAULT_CONTRACT_BYTE_LENGTH).join(','),
+  }
+}
 
 type DelayedContractStateRecoveryEvent = {
   address: string
@@ -89,9 +111,6 @@ export const wasm: HandlerMaker<WasmExportData> = async ({
       'Chain ID needed for wasm export, failed to load from RPC or State model in DB.'
     )
   }
-
-  const CONTRACT_KEY_PREFIX = 0x02
-  const CONTRACT_STORE_PREFIX = 0x03
 
   // Get the contract state event allowlist.
   const stateEventAllowlist = CONTRACT_STATE_EVENT_KEY_ALLOWLIST[chainId]?.map(
@@ -166,42 +185,19 @@ export const wasm: HandlerMaker<WasmExportData> = async ({
     //
     //     ContractKeyPrefix || contractAddressBytes
     //
-    const keyData = fromBase64(trace.key)
-    if (
-      keyData[0] !== CONTRACT_STORE_PREFIX &&
-      keyData[0] !== CONTRACT_KEY_PREFIX
-    ) {
+    const parsedKey = parseWasmStoreKey(trace.key, bech32Prefix)
+    if (!parsedKey) {
       return
     }
 
-    const contractByteLength = DEFAULT_CONTRACT_BYTE_LENGTH
-    // Start of contract address in the key, taking into account the prefix.
-    const contractAddressOffset = 1
-
-    // Ignore keys that are too short to be a wasm key.
-    if (keyData.length < contractAddressOffset + contractByteLength) {
-      return
-    }
-
-    const contractAddress = toBech32(
-      bech32Prefix,
-      keyData.slice(
-        contractAddressOffset,
-        contractAddressOffset + contractByteLength
-      )
-    )
-    // Convert key to comma-separated list of bytes. See explanation in `Event`
-    // model for more information.
-    const key = keyData
-      .slice(contractAddressOffset + contractByteLength)
-      .join(',')
+    const { contractAddress, prefix, stateKey: key } = parsedKey
 
     // Get code ID and block timestamp from chain.
     const blockHeight = BigInt(trace.metadata.blockHeight).toString()
     const blockTimeUnixMs = BigInt(trace.blockTimeUnixMs).toString()
 
     // If contract key, save contract info.
-    if (trace.operation === 'write' && keyData[0] === CONTRACT_KEY_PREFIX) {
+    if (trace.operation === 'write' && prefix === CONTRACT_KEY_PREFIX) {
       // Parse as protobuf to get code ID.
       const protobufContractInfo = fromBase64(trace.value)
       let contractInfo


### PR DESCRIPTION
## Purpose

Related to #50.

Add a lightweight, source-derived characterization of the exact wasm store keys used by Juno v30 while preserving Argus's existing production parsing behavior. This was split from the infrastructure fix in PR #51 at the request of the maintainer.

## Context

Juno `v30.0.0` resolves to [`c0b3a8d258d52d16e5bc39a75168a99aab9d098e`](https://github.com/CosmosContracts/juno/commit/c0b3a8d258d52d16e5bc39a75168a99aab9d098e). Its [`go.mod` requires wasmd `v0.61.11`](https://github.com/CosmosContracts/juno/blob/c0b3a8d258d52d16e5bc39a75168a99aab9d098e/go.mod#L1-L31), with [no replacement for wasmd or wasmvm](https://github.com/CosmosContracts/juno/blob/c0b3a8d258d52d16e5bc39a75168a99aab9d098e/go.mod#L472-L492). wasmd `v0.61.11` resolves to [`fcf8565dcf9531d27fc75ced1b0b0167072345a8`](https://github.com/CosmWasm/wasmd/commit/fcf8565dcf9531d27fc75ced1b0b0167072345a8).

That source defines [`ContractKeyPrefix = 0x02` and `ContractStorePrefix = 0x03`](https://github.com/CosmWasm/wasmd/blob/fcf8565dcf9531d27fc75ced1b0b0167072345a8/x/wasm/types/keys.go#L27-L38), with [raw decoded address bytes appended by the key constructors](https://github.com/CosmWasm/wasmd/blob/fcf8565dcf9531d27fc75ced1b0b0167072345a8/x/wasm/types/keys.go#L50-L64). [Contract state is stored below the contract store prefix](https://github.com/CosmWasm/wasmd/blob/fcf8565dcf9531d27fc75ced1b0b0167072345a8/x/wasm/keeper/keeper.go#L982-L1009), and [contract info uses the contract info key](https://github.com/CosmWasm/wasmd/blob/fcf8565dcf9531d27fc75ced1b0b0167072345a8/x/wasm/keeper/keeper.go#L1054-L1083).

The affected Juno contract decodes to a 32-byte address, so state remains `0x03 || address || key`, with the VM key beginning at offset 33. This matches Argus's existing logic.

## Changes

- Extract the existing wasm key parsing into a small exported pure function.
- Add exact Juno v30 contract info and contract state key fixtures.
- Keep prefixes, address length, offset, and runtime matching behavior unchanged.

## Verification

- Focused parser and delayed-recovery suite: 2 files, 4 tests passed.
- `npm run lint`: passed.
- `npm run build`: passed; only pre-existing CommonJS migration warnings were emitted.
- `git diff --check`: passed.
